### PR TITLE
Add catalog preview and product pages

### DIFF
--- a/src/app/catalogo/[...slug]/page.tsx
+++ b/src/app/catalogo/[...slug]/page.tsx
@@ -1,0 +1,40 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { getAllSlugs, getItem } from "@/lib/catalog";
+
+export async function generateStaticParams() {
+    const slugs = await getAllSlugs();
+    return slugs.map((slug) => ({ slug }));
+}
+
+export default async function CatalogItemPage({
+    params,
+}: {
+    params: { slug: string[] };
+}) {
+    const item = await getItem(params.slug);
+    if (!item) return notFound();
+
+    return (
+        <main className="mx-auto max-w-screen-lg px-4 py-8">
+            <h1 className="mb-4 text-3xl font-bold">{item.titulo}</h1>
+            {item.descricao && (
+                <p className="mb-6 max-w-prose text-muted-foreground">
+                    {item.descricao}
+                </p>
+            )}
+            <div className="grid gap-4 sm:grid-cols-2">
+                {item.imagens?.map((img) => (
+                    <Image
+                        key={img}
+                        src={`/Organizado/${item.dir}/${img}`}
+                        alt={item.titulo}
+                        width={800}
+                        height={600}
+                        className="w-full object-contain"
+                    />
+                ))}
+            </div>
+        </main>
+    );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
-"use client";
-
 import dynamic from "next/dynamic";
+import CatalogPreview from "@/components/catalogo/CatalogPreview";
 
 const StartCarousel = dynamic(() => import("@/components/StartCarousel"), {
     ssr: false,
@@ -12,6 +11,7 @@ export default function Home() {
     return (
         <>
             <StartCarousel />
+            <CatalogPreview limit={6} />
             <Main />
         </>
     );

--- a/src/components/catalogo/CatalogPreview.tsx
+++ b/src/components/catalogo/CatalogPreview.tsx
@@ -1,0 +1,49 @@
+/* Server Component: mostra alguns itens do catálogo */
+import Image from "next/image";
+import Link from "next/link";
+import { FiImage } from "react-icons/fi";
+import { getCatalog } from "@/lib/catalog";
+import { Button } from "@/components/ui/button";
+
+export default async function CatalogPreview({ limit = 6 }: { limit?: number }) {
+    const itens = await getCatalog(limit);
+
+    return (
+        <section className="mx-auto max-w-screen-xl px-4 py-8">
+            <h2 className="mb-6 text-2xl font-bold">Catálogo</h2>
+            <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4">
+                {itens.map((it) => (
+                    <Link
+                        href={`/catalogo/${encodeURIComponent(it.key)}`}
+                        key={it.key}
+                        className="group flex flex-col overflow-hidden rounded-lg border"
+                    >
+                        {it.imagens?.[0] ? (
+                            <Image
+                                src={`/Organizado/${it.key}/${it.imagens[0]}`}
+                                alt={it.titulo}
+                                width={320}
+                                height={240}
+                                className="h-32 w-full object-cover transition duration-300 group-hover:scale-105"
+                            />
+                        ) : (
+                            <div className="flex h-32 w-full items-center justify-center bg-muted">
+                                <FiImage className="text-2xl text-muted-foreground" />
+                            </div>
+                        )}
+                        <div className="p-2">
+                            <h3 className="text-sm font-semibold truncate">
+                                {it.titulo}
+                            </h3>
+                        </div>
+                    </Link>
+                ))}
+            </div>
+            <div className="mt-6 text-center">
+                <Button asChild>
+                    <Link href="/catalogo">Ver catálogo completo</Link>
+                </Button>
+            </div>
+        </section>
+    );
+}

--- a/src/components/catalogo/Catalogo.tsx
+++ b/src/components/catalogo/Catalogo.tsx
@@ -1,35 +1,8 @@
 /* Server Component: gera HTML durante o build */
-import fs from "node:fs/promises";
-import path from "node:path";
 import Image from "next/image";
 import Link from "next/link";
 import { FiImage } from "react-icons/fi";
-
-interface Metadata {
-    titulo: string;
-    descricao?: string;
-    imagens?: string[];
-}
-
-async function getCatalog(): Promise<(Metadata & { key: string })[]> {
-    const root = path.join(process.cwd(), "Organizado");
-    const out: (Metadata & { key: string })[] = [];
-
-    async function walk(dir: string) {
-        const list = await fs.readdir(dir, { withFileTypes: true });
-        for (const itm of list) {
-            const abs = path.join(dir, itm.name);
-            if (itm.isDirectory()) await walk(abs);
-            if (itm.name === "metadata.json") {
-                const raw = await fs.readFile(abs, "utf8");
-                const data = JSON.parse(raw) as Metadata;
-                out.push({ ...data, key: path.relative(root, dir) });
-            }
-        }
-    }
-    await walk(root);
-    return out;
-}
+import { getCatalog } from "@/lib/catalog";
 
 export default async function Catalogo() {
     const itens = await getCatalog();
@@ -41,13 +14,13 @@ export default async function Catalogo() {
             <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
                 {itens.map((it) => (
                     <Link
-                        href={`/itens/${encodeURIComponent(it.key)}`}
+                        href={`/catalogo/${encodeURIComponent(it.key)}`}
                         key={it.key}
                         className="group flex flex-col overflow-hidden rounded-lg border"
                     >
                         {it.imagens?.[0] ? (
                             <Image
-                                src={it.imagens[0]}
+                                src={`/Organizado/${it.key}/${it.imagens[0]}`}
                                 alt={it.titulo}
                                 width={640}
                                 height={480}

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface CatalogItem {
+    key: string;
+    titulo: string;
+    descricao?: string;
+    imagens?: string[];
+}
+
+const rootDir = path.join(process.cwd(), 'public', 'Organizado');
+
+async function walk(dir: string, segments: string[], out: CatalogItem[], limit?: number) {
+    if (limit && out.length >= limit) return;
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            const metaPath = path.join(abs, 'metadata.json');
+            try {
+                const raw = await fs.readFile(metaPath, 'utf8');
+                const data = JSON.parse(raw) as Omit<CatalogItem, 'key'>;
+                out.push({ ...data, key: [...segments, entry.name].join('/') });
+                if (limit && out.length >= limit) return;
+            } catch {
+                await walk(abs, [...segments, entry.name], out, limit);
+            }
+        }
+    }
+}
+
+export async function getCatalog(limit?: number): Promise<CatalogItem[]> {
+    const items: CatalogItem[] = [];
+    await walk(rootDir, [], items, limit);
+    return items;
+}
+
+export async function getItem(slug: string[]): Promise<(CatalogItem & { dir: string }) | null> {
+    const dir = path.join(rootDir, ...slug);
+    try {
+        const raw = await fs.readFile(path.join(dir, 'metadata.json'), 'utf8');
+        const data = JSON.parse(raw) as Omit<CatalogItem, 'key'>;
+        return { ...data, key: slug.join('/'), dir: slug.join('/') };
+    } catch {
+        return null;
+    }
+}
+
+export async function getAllSlugs(): Promise<string[][]> {
+    const slugs: string[][] = [];
+    async function walkDirs(dir: string, segments: string[]) {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        for (const entry of entries) {
+            const abs = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                const metaPath = path.join(abs, 'metadata.json');
+                try {
+                    await fs.access(metaPath);
+                    slugs.push([...segments, entry.name]);
+                } catch {
+                    await walkDirs(abs, [...segments, entry.name]);
+                }
+            }
+        }
+    }
+    await walkDirs(rootDir, []);
+    return slugs;
+}


### PR DESCRIPTION
## Summary
- create util functions to load catalog items from `public/Organizado`
- build catalog preview component with limited items and link to full catalog
- update catalog component to use new util and correct paths
- implement dynamic product page under `/catalogo/[...slug]`
- show catalog preview on the landing page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d70deb0fc8331845c841efb4c2db3