### PR TITLE
Add catalog preview to homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
-"use client";
-
 import dynamic from "next/dynamic";
+import CatalogPreview from "@/components/catalogo/CatalogPreview";
 
 const StartCarousel = dynamic(() => import("@/components/StartCarousel"), {
     ssr: false,
@@ -12,6 +11,7 @@ export default function Home() {
     return (
         <>
             <StartCarousel />
+            <CatalogPreview limit={6} />
             <Main />
             <a
                 href="https://wa.me/+551142377766"


### PR DESCRIPTION
## Summary
- remove `use client` directive from home page to allow server component usage
- show a small catalog preview on the landing page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7ebc1f04833194a2950f6f5a983c