### PR TITLE
Arrumar imports server-only e configurar sitemap

### DIFF
--- a/next-sitemap.config.mjs
+++ b/next-sitemap.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  siteUrl: 'https://www.alugueldegames.com',
+  generateRobotsTxt: true,
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev --turbo --hostname 0.0.0.0",
     "build": "next build",
+    "postbuild": "next-sitemap",
     "start": "next start",
     "lint": "next lint"
   },
@@ -42,6 +43,7 @@
     "eslint-config-next": "15.3.3",
     "tailwindcss": "^4.1.10",
     "tw-animate-css": "^1.3.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "next-sitemap": "^5.7.4"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import CatalogPreview from '@/components/catalogo/CatalogPreview'
 import HomeShell from '@/components/HomeShell'
+import CatalogList from './catalogo/CatalogList.server'
 
 export default function Home() {
     return (
         <>
             <HomeShell/> {/* parte interativa no cliente */}
+            <CatalogList order={['Fliperamas', 'Air Games']} limitPerCat={6} />
             <a
                 href="https://wa.me/+551142377766"
                 target="_blank"

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -8,7 +8,6 @@ import {DynamicGradient} from "@/components/hooks/DynamicGradient";
 
 /*  ↓ importe as seções pesadas via dynamic para evitar SSR de GSAP etc. */
 import dynamic from "next/dynamic";
-import CatalogList from "@/app/catalogo/CatalogList.server";
 
 const TopToys      = dynamic(() => import("@/components/sections/top-toys/TopToys"),      { ssr: false });
 const ComoFunciona = dynamic(() => import("@/components/sections/como-funciona/ComoFunciona"), { ssr: false });
@@ -71,7 +70,6 @@ export default function Main() {
                 </div>
             </section>
 
-            <CatalogList order={['Fliperamas', 'Air Games']} limitPerCat={6} />
 
             {/* =============== SECTION 4 — CALL TO ACTION =============== */}
             <section className="rounded-md bg-secondary py-10 px-5 text-secondary-foreground">


### PR DESCRIPTION
## Resumo
- remover CatalogList.server de Main.tsx para evitar erro de build
- mover CatalogList para `app/page.tsx`
- adicionar configuração do next‑sitemap e script pós-build

## Testes
- `npm run build` *(falhou: `next` não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_685dd82876948331a16c6348f942e5bd