### PR TITLE
Corrigir 404 ao manter case original das URLs

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,13 +17,11 @@ export function middleware(request: NextRequest) {
     //     return NextResponse.redirect(url, 301);
     // }
 
-    // Forçar lowercase nas URLs para evitar duplicação
-    // Forçar lowercase nas URLs para evitar duplicação, ignorando arquivos estáticos
-    const hasExtension = url.pathname.includes('.')
-    if (!hasExtension && url.pathname !== url.pathname.toLowerCase()) {
-        url.pathname = url.pathname.toLowerCase();
-        return NextResponse.redirect(url, 301);
-    }
+    // Anteriormente forçávamos todas as URLs para lowercase a fim de evitar
+    // duplicação. Contudo, isso causava erro 404 quando as pastas possuíam
+    // letras maiúsculas ou caracteres especiais (ex.: /catalogo/Air%20Games).
+    // Por isso, removemos essa conversão e mantemos o case original da URL,
+    // permitindo o acesso correto a pastas com espaços ou acentuação.
 
     // Headers de segurança e SEO
     const response = NextResponse.next();


### PR DESCRIPTION
## Resumo
- remover redirecionamento que convertia as URLs para lowercase no middleware
- preservar letras maiúsculas e caracteres especiais em rotas como `/catalogo`

## Testes
- `npm test` *(falha: script ausente)*
- `npm run lint` *(falha: Next não instalado no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68684daaf8008331a1d2deae7ae435e8